### PR TITLE
Fix JS comment and end-of-file newline

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -265,7 +265,7 @@ function setup() {
 function draw() {
   clear()
 
-  // Outher circle
+  // Outer circle
   noStroke();
   ellipse(x, y, 260, 260);
 


### PR DESCRIPTION
## Summary
- corrected the circle drawing comment
- added a trailing newline to `assets/js/main.js`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841a506cb04832aaf546659e25d904a