### PR TITLE
Add Jest tests for countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # breathely
+
+## Running Tests
+
+1. Install dependencies with `npm install`.
+2. Execute all Jest tests with `npm test`.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -373,3 +373,8 @@ button_close.addEventListener('click', function () {
 button_close_done.addEventListener('click', function () {
   window.location.reload();
 })
+
+// Expose countdown for testing environments
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { countDown };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "breathely",
+  "version": "1.0.0",
+  "description": "",
+  "main": "service-worker.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/countDown.test.js
+++ b/tests/countDown.test.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const ids = [
+  'installContainer','butInstall','requireHTTPS','customize_open','customize_menu','customize_close',
+  'button_start','button_begin','button_cancel','button_pause_play','settings','countdown','my_sketch','intro',
+  'info_open','info_overlay','info_close','three_min_intro','five_min_intro','ten_min_intro','twenty_min_intro',
+  'three_min','five_min','ten_min','twenty_min','sound1_intro','sound2_intro','sound9_intro',
+  'sound1','sound2','sound9','status','cancel_overlay','done_overlay','button_close','button_close_done'
+];
+
+describe('countDown', () => {
+  let countDown;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<!DOCTYPE html><body></body>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.navigator = dom.window.navigator;
+
+    ids.forEach(id => {
+      const el = document.createElement('div');
+      el.id = id;
+      document.body.appendChild(el);
+    });
+
+    document.getElementById('requireHTTPS').appendChild(document.createElement('a'));
+
+    global.song_played = { stop: jest.fn() };
+
+    jest.useFakeTimers();
+    countDown = require('../assets/js/main.js').countDown;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('updates status and clears timer when seconds reach zero', () => {
+    const status = document.getElementById('status');
+    countDown(1, 'status');
+    expect(status.innerHTML).toBe('00:01');
+    expect(jest.getTimerCount()).toBe(1);
+
+    jest.runOnlyPendingTimers();
+
+    expect(status.innerHTML).toBe(' ');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with jsdom
- export `countDown` for testing
- add countdown unit test
- document test usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659c901e50832abaf9be5518e633f0